### PR TITLE
Update ansible-lint hook and get rid of workaround

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.3.5
+    rev: v4.3.7
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,32 +6,27 @@
     path: "{{ install_dir }}"
     state: directory
 
-# TODO: All of the include_tasks below should really be
-# ansible.builtin.include_tasks, but when I do that ansible-lint
-# (which is called via a pre-commit hook) complains.  See this issue:
-# https://github.com/cisagov/ansible-role-assessment-tool/issues/4
-
 - name: Install the tool if necessary
-  include_tasks: install_tool.yml
+  ansible.builtin.include_tasks: install_tool.yml
   when:
     - archive_src is defined
 
 - name: Install mono if necessary
-  include_tasks: install_mono.yml
+  ansible.builtin.include_tasks: install_mono.yml
   when:
     - csharp
 
 - name: Install Python 2 if necessary
-  include_tasks: install_python2.yml
+  ansible.builtin.include_tasks: install_python2.yml
   when:
     - python2
 
 - name: Create a Python virtualenv if necessary
-  include_tasks: create_python_venv.yml
+  ansible.builtin.include_tasks: create_python_venv.yml
   when:
     - pip_packages is defined or pip_requirements_file is defined
 
 - name: Install powershell if necessary
-  include_tasks: install_powershell.yml
+  ansible.builtin.include_tasks: install_powershell.yml
   when:
     - powershell


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the ansible-lint `pre-commit` hook, which in turn allows us to update some places where a bug in the old ansible-lint hook forced us to use the "short" Ansible module name (`include_tasks`) instead of the "full" name (`ansible.builtin.include_tasks`).

## 💭 Motivation and Context ##

Although frowned at on the fashion runway, stylistic monotony is paramount in software development.

Resolves #4.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
