### PR TITLE
Add support for Debian and Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-assessment-tool.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-assessment-tool/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-assessment-tool.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-assessment-tool/context:python)
 
-This Ansible role is used to install assessment tools to Kali Linux.
-This role can also be configured to provide some language-specific
-extras:
+This Ansible role is used to install assessment tools to Debian,
+Ubuntu, or Kali Linux.  This role can also be configured to provide
+some language-specific extras:
 
 * C# - The `csharp` role variable can be set to `yes` to install the
   [Mono Project](https://www.mono-project.com/) tools for C#

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,10 +18,21 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
+        - buster
         # Kali linux isn't an option here, but it is based on
         # Debian Testing:
         # https://www.kali.org/docs/policy/kali-linux-relationship-with-debian
-        - bullseye
+        #
+        # Unfortunately, the Debian Bullseye deb packages available at
+        # https://github.com/PowerShell/PowerShell do not install on a
+        # recent Debian Bullseye instance due to broken dependencies.
+        # Kali Linux provides its own package, so it still works, but
+        # we cannot support Debian Bullseye right now.
+        # - bullseye
+    - name: Ubuntu
+      versions:
+        - bionic
+        - focal
   role_name: assessment_tool
 
 dependencies: []

--- a/molecule/csharp/molecule.yml
+++ b/molecule/csharp/molecule.yml
@@ -16,8 +16,14 @@ lint: |
   ansible-lint
   flake8
 platforms:
+  - name: debian10
+    image: debian:buster-slim
   - name: kali
     image: kalilinux/kali-rolling
+  - name: ubuntu18
+    image: ubuntu:bionic
+  - name: ubuntu20
+    image: ubuntu:focal
 provisioner:
   name: ansible
   config_options:

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,8 +16,14 @@ lint: |
   ansible-lint
   flake8
 platforms:
+  - name: debian10
+    image: debian:buster-slim
   - name: kali
     image: kalilinux/kali-rolling
+  - name: ubuntu18
+    image: ubuntu:bionic
+  - name: ubuntu20
+    image: ubuntu:focal
 provisioner:
   name: ansible
   config_options:

--- a/molecule/powershell/molecule.yml
+++ b/molecule/powershell/molecule.yml
@@ -16,8 +16,14 @@ lint: |
   ansible-lint
   flake8
 platforms:
+  - name: debian10
+    image: debian:buster-slim
   - name: kali
     image: kalilinux/kali-rolling
+  - name: ubuntu18
+    image: ubuntu:bionic
+  - name: ubuntu20
+    image: ubuntu:focal
 provisioner:
   name: ansible
   config_options:

--- a/molecule/python/molecule.yml
+++ b/molecule/python/molecule.yml
@@ -16,8 +16,14 @@ lint: |
   ansible-lint
   flake8
 platforms:
+  - name: debian10
+    image: debian:buster-slim
   - name: kali
     image: kalilinux/kali-rolling
+  - name: ubuntu18
+    image: ubuntu:bionic
+  - name: ubuntu20
+    image: ubuntu:focal
 provisioner:
   name: ansible
   config_options:

--- a/tasks/install_powershell_Debian.yml
+++ b/tasks/install_powershell_Debian.yml
@@ -1,0 +1,4 @@
+---
+- name: Install powershell if necessary
+  ansible.builtin.apt:
+    deb: "{{ powershell_package_name }}"

--- a/tasks/install_powershell_Debian.yml
+++ b/tasks/install_powershell_Debian.yml
@@ -1,4 +1,4 @@
 ---
-- name: Install powershell if necessary
+- name: Install PowerShell if necessary
   ansible.builtin.apt:
     deb: "{{ powershell_package_name }}"

--- a/tasks/install_powershell_Kali.yml
+++ b/tasks/install_powershell_Kali.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install powershell if necessary
+- name: Install PowerShell if necessary
   ansible.builtin.package:
     name:
       - "{{ powershell_package_name }}"

--- a/tasks/install_powershell_Kali.yml
+++ b/tasks/install_powershell_Kali.yml
@@ -2,4 +2,4 @@
 - name: Install powershell if necessary
   ansible.builtin.package:
     name:
-      - powershell
+      - "{{ powershell_package_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
   when:
     - pip_packages is defined or pip_requirements_file is defined
 
-- name: Install powershell if necessary
+- name: Install PowerShell if necessary
   ansible.builtin.include_tasks: "{{ lookup('first_found', params) }}"
   vars:
     params:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Load var file with package names based on the OS type
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      paths:
+        - "{{ role_path }}/vars"
+
 - name: Create the directory {{ install_dir }}
   ansible.builtin.file:
     group: "{{ group }}"
@@ -27,6 +38,14 @@
     - pip_packages is defined or pip_requirements_file is defined
 
 - name: Install powershell if necessary
-  ansible.builtin.include_tasks: install_powershell.yml
+  ansible.builtin.include_tasks: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - install_powershell_{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml
+        - install_powershell_{{ ansible_distribution }}.yml
+        - install_powershell_{{ ansible_os_family }}.yml
+      paths:
+        - "{{ role_path }}/tasks"
   when:
     - powershell

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,3 @@
 ---
-# The name of the package to install for Powershell
+# The name of the package to install for PowerShell
 powershell_package_name: https://github.com/PowerShell/PowerShell/releases/download/v7.1.2/powershell_7.1.2-1.{{ ansible_distribution | lower }}.{{ ansible_distribution_major_version }}_amd64.deb

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,3 @@
+---
+# The name of the package to install for Powershell
+powershell_package_name: https://github.com/PowerShell/PowerShell/releases/download/v7.1.2/powershell_7.1.2-1.{{ ansible_distribution | lower }}.{{ ansible_distribution_major_version }}_amd64.deb

--- a/vars/Kali.yml
+++ b/vars/Kali.yml
@@ -1,3 +1,3 @@
 ---
-# The name of the package to install for Powershell
+# The name of the package to install for PowerShell
 powershell_package_name: powershell

--- a/vars/Kali.yml
+++ b/vars/Kali.yml
@@ -1,0 +1,3 @@
+---
+# The name of the package to install for Powershell
+powershell_package_name: powershell

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,3 +1,3 @@
 ---
-# The name of the package to install for Powershell
+# The name of the package to install for PowerShell
 powershell_package_name: https://github.com/PowerShell/PowerShell/releases/download/v7.1.2/powershell_7.1.2-1.{{ ansible_distribution | lower }}.{{ ansible_distribution_version }}_amd64.deb

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,3 @@
+---
+# The name of the package to install for Powershell
+powershell_package_name: https://github.com/PowerShell/PowerShell/releases/download/v7.1.2/powershell_7.1.2-1.{{ ansible_distribution | lower }}.{{ ansible_distribution_version }}_amd64.deb


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds support for Debian and Ubuntu.  Only the `powershell` Molecule scenario needed to be modified - the other scenarios worked without modification.

## 💭 Motivation and context ##

This change is required for the changes in cisagov/teamserver-packer@47188ca (part of cisagov/teamserver-packer#27) to work.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  I also successfully used these changes to build a new COOL teamserver AMI in cisagov/teamserver-packer#27.  That is a very good test since it applies this role to a Debian Buster base AMI.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
