### PR TITLE
Remove antiquated syntax

### DIFF
--- a/molecule/python/tests/test_python.py
+++ b/molecule/python/tests/test_python.py
@@ -57,8 +57,6 @@ def test_venvs(host, d, pkgs):
     assert directory.exists
     assert directory.is_directory
     # Make sure that the virtualenv contains the expected packages
-    installed_pkgs = host.pip_package.get_packages(
-        pip_path=os.path.join(d, "bin", "pip")
-    )
+    installed_pkgs = host.pip.get_packages(pip_path=os.path.join(d, "bin", "pip"))
     for pkg in pkgs:
         assert pkg in installed_pkgs


### PR DESCRIPTION
## 🗣 Description ##

This pull request exchanges some antiquated [pytest-dev/pytest-testinfra](https://github.com/pytest-dev/pytest-testinfra) syntax for its more modern form.

## 💭 Motivation and context ##

I was rooting around in this repository while debugging something and noticed a warning due to the use of the older syntax.  I thought I would go ahead and fix the issue while I was here, so when the old syntax is no longer supported we won't be taken by surprise.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
