### PR TITLE
Allow specification of install directory owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,6 @@ environment:
         install_dir: /tools/mitm6
         pip_packages:
           - mitm6
-        unarchive_extra_opts:
-          - --strip-components=1
 ```
 
 ### Installing a Tool That Is Not Based on C#, PowerShell, or Python ###

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ None.
   should be installed.  Required.
 - `mode` - the mode to assign the directory where this tool is
   installed.  Defaults to 0775.
+- `owner` - the user that will own the directory where this tool is
+  installed.  Defaults to root.
 - `pip_packages` - a list of pip packages to install into the Python
   virtualenv.
 - `pip_requirements_file` - path to a pip requirements file listing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ group: root
 # Mode for the install directory
 mode: 0775
 
+# User ownership for the install directory
+owner: root
+
 # If this is a PowerShell project then we will install the powershell
 # system package
 powershell: no

--- a/molecule/python/converge.yml
+++ b/molecule/python/converge.yml
@@ -30,5 +30,3 @@
         install_dir: /tools/mitm6
         pip_packages:
           - mitm6
-        unarchive_extra_opts:
-          - --strip-components=1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
   ansible.builtin.file:
     group: "{{ group }}"
     mode: "{{ mode }}"
+    owner: "{{ owner }}"
     path: "{{ install_dir }}"
     state: directory
 
@@ -49,3 +50,13 @@
         - "{{ role_path }}/tasks"
   when:
     - powershell
+
+- name: >-
+    Ensure that the contents of the install directory have the correct
+    user and group ownership
+  ansible.builtin.file:
+    group: "{{ group }}"
+    owner: "{{ owner }}"
+    path: "{{ install_dir }}"
+    recurse: yes
+    state: directory


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to allow the user to specify the owner of the install directory.  It also ensures that the contents of the install directory have the same owner and group as the directory itself after everything has been installed.  The first change is an improvement while the second fixes a bug.

## 💭 Motivation and context ##

The specification of the owner of the install directory is necessary as part of cisagov/terraformer-packer#1, and the application of the owner and group to the contents of the install directory is a bug I noticed while implementing that change.

## 🧪 Testing ##

Successfully tested as part of cisagov/terraformer-packer#1.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
