### PR TITLE
Add support for Go-based tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
         scenario:
           - csharp
           - default
+          - go
           - powershell
           - python
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
     hooks:
       - id: bandit
         # Bandit complains about the use of assert() in tests
-        exclude: molecule/(csharp|default|powershell|python)/tests
+        exclude: molecule/(csharp|default|go|powershell|python)/tests
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ some language-specific extras:
 - C# - The `csharp` role variable can be set to `yes` to install the
   [Mono Project](https://www.mono-project.com/) tools for C#
   development on Linux.
+- Go - The `go` role variable can be set to `yes` to install the
+  [Go](https://go.dev/) development tools.
 - PowerShell - The `powershell` role variable can be set to `yes` to
   install [PowerShell](https://en.wikipedia.org/wiki/PowerShell).
 - Python - The `python` role variable can be set to `yes` and used in
@@ -48,6 +50,7 @@ None.
 |----------|-------------|---------|----------|
 | archive_src | A URL or a file path on the remote host pointing to an archive (tar or zip) containing the tool.  If left undefined then no archive will be installed, but the install directory will still be created and language-specific tooling will still be installed. | n/a | No |
 | csharp | A Boolean indicating whether or not the tool is written in C#; if it is then we will install the mono C# toolchain. | `false` | No |
+| go | A Boolean indicating whether or not the tool is written in Go; if it is then we will install the Go development toolchain. | `false` | No |
 | group | The group that will own the directory where this tool is installed. | `root` | No |
 | install_dir | The directory on the remote host where the tool should be installed. | n/a | Yes |
 | mode | The mode to assign the directory where this tool is installed. | `0775` | No |
@@ -79,6 +82,24 @@ Here's how to use it in a playbook to install a C# tool:
         archive_src: https://github.com/eladshamir/Internal-Monologue/tarball/master
         install_dir: /tools/Internal-Monologue
         csharp: yes
+        unarchive_extra_opts:
+          - --strip-components=1
+```
+
+### Installing a Go Tool ###
+
+Here's how to use it in a playbook to install a Go tool:
+
+```yaml
+- hosts: all
+  become: yes
+  become_method: sudo
+  roles:
+    - role: assessment_tool
+      vars:
+        archive_src: https://github.com/optiv/ScareCrow/tarball/main
+        install_dir: /tools/ScareCrow
+        go: yes
         unarchive_extra_opts:
           - --strip-components=1
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@
 # to compile C# code
 csharp: no
 
+# If this is a Go project then we will install the Go development
+# toolchain required to compile Go code
+go: no
+
 # Group ownership for the install directory
 group: root
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,10 +4,10 @@ galaxy_info:
   description: An Ansible role for installing an assessment tool from a remote archive
   company: CISA Cyber Assessments
   galaxy_tags:
-    - assessment
     - archive
-    - go
+    - assessment
     - csharp
+    - go
     - mono
     - python
   license: CC0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,6 +6,8 @@ galaxy_info:
   galaxy_tags:
     - assessment
     - archive
+    - go
+    - csharp
     - mono
     - python
   license: CC0

--- a/molecule/go/INSTALL.rst
+++ b/molecule/go/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/go/converge.yml
+++ b/molecule/go/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Install ScareCrow
+      ansible.builtin.include_role:
+        name: ansible-role-assessment-tool
+      vars:
+        archive_src: https://github.com/optiv/ScareCrow/tarball/main
+        install_dir: /tools/ScareCrow
+        go: yes
+        unarchive_extra_opts:
+          - --strip-components=1

--- a/molecule/go/molecule-no-systemd.yml
+++ b/molecule/go/molecule-no-systemd.yml
@@ -1,0 +1,1 @@
+../default/molecule-no-systemd.yml

--- a/molecule/go/molecule-with-systemd.yml
+++ b/molecule/go/molecule-with-systemd.yml
@@ -1,0 +1,1 @@
+../default/molecule-with-systemd.yml

--- a/molecule/go/molecule.yml
+++ b/molecule/go/molecule.yml
@@ -1,0 +1,76 @@
+---
+# This molecule configuration file is suitable for testing Ansible
+# roles that _do not_ require SystemD.  If your Ansible role _does_
+# require SystemD then you should use molecule-with-systemd.yml
+# instead.
+#
+# Note that the molecule configuration file that is symlinked to
+# molecule.yml is the one that will be used.
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: debian10
+    image: debian:buster-slim
+  - name: debian11
+    image: debian:bullseye-slim
+  - name: kali
+    image: kalilinux/kali-rolling
+  - name: ubuntu18
+    image: ubuntu:bionic
+  - name: ubuntu20
+    image: ubuntu:focal
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      # By default, when using vars: within the roles: section of a
+      # playbook, the variables are added to the play variables.  This
+      # is normally not a problem, but it definitely can be if you are
+      # running the same role more than once with a different set of
+      # vars.  Fortunately, Ansible provides a configuration setting
+      # to enable private role variables, so we use it here.
+      #
+      # See:
+      # * https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#using-roles-at-the-play-level
+      # * https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-private-role-vars
+      private_role_vars: true
+  inventory:
+    host_vars:
+      debian9:
+        # auto_legacy is still the default behavior until Ansible 2.12
+        # is released, but Molecule overrides this and forces the use
+        # of auto.
+        #
+        # In auto_legacy mode Ansible will prefer the /usr/bin/python
+        # interpreter if it exists, while in auto mode it will prefer
+        # the Python interpreter specified in an internal map.  In
+        # most cases we only have Python3 installed, and the internal
+        # map specifies /usr/bin/python3, so it is immaterial whether
+        # we use auto_legacy or auto.
+        #
+        # The one place where it _does_ matter is our Debian9 AKA CyHy
+        # instances.  Here the /usr/bin/python _and_ /usr/bin/python3
+        # interpreters are both installed.  In Ansible 2.10 a Debian
+        # entry was added to the internal map, so now auto_legacy
+        # selects the /usr/bin/python interpreter while auto selects
+        # the /usr/bin/python3 interpreter.  We want to maintain the
+        # auto_legacy behavior in this case since CyHy is still
+        # Python2.
+        #
+        # See:
+        # * https://github.com/ansible-community/molecule/blob/3.0.8/molecule/provisioner/ansible.py#L389
+        # * https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/config/base.yml#L1492-L1542
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/executor/interpreter_discovery.py
+        ansible_python_interpreter: auto_legacy
+scenario:
+  name: go
+verifier:
+  name: testinfra

--- a/molecule/go/prepare.yml
+++ b/molecule/go/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/go/python.yml
+++ b/molecule/go/python.yml
@@ -1,0 +1,1 @@
+../default/python.yml

--- a/molecule/go/requirements.yml
+++ b/molecule/go/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/go/tests/test_go.py
+++ b/molecule/go/tests/test_go.py
@@ -1,0 +1,38 @@
+"""Module containing the tests for the go scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+@pytest.mark.parametrize(
+    "d",
+    [
+        "/tools/ScareCrow",
+    ],
+)
+def test_directories(host, d):
+    """Test that appropriate directories were created."""
+    directory = host.file(d)
+    assert directory.exists
+    assert directory.is_directory
+    # Make sure that the directory is not empty
+    assert host.run_expect([0], f'[ -n "$(ls -A {d})" ]')
+
+
+@pytest.mark.parametrize(
+    "pkg",
+    [
+        "golang",
+    ],
+)
+def test_packages(host, pkg):
+    """Test that appropriate packages were installed."""
+    assert host.package(pkg).is_installed

--- a/molecule/go/tests/test_go.py
+++ b/molecule/go/tests/test_go.py
@@ -30,6 +30,7 @@ def test_directories(host, d):
 @pytest.mark.parametrize(
     "pkg",
     [
+        "git",
         "golang",
     ],
 )

--- a/molecule/go/upgrade.yml
+++ b/molecule/go/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/tasks/install_go.yml
+++ b/tasks/install_go.yml
@@ -1,0 +1,7 @@
+---
+- name: Install Go toolchain and Git
+  ansible.builtin.package:
+    name:
+      # Third-party Go packages are often installed via git
+      - git
+      - golang

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,11 @@
   when:
     - archive_src is defined
 
+- name: Install Go toolchain if necessary
+  ansible.builtin.include_tasks: install_go.yml
+  when:
+    - go
+
 - name: Install mono if necessary
   ansible.builtin.include_tasks: install_mono.yml
   when:


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds to this Ansible role support for Go-based tools.

## 💭 Motivation and context ##

Part of the resolution (along with cisagov/kali-packer#86) of cisagov/cool-system-internal#69.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
