### PR TITLE
Extend Go support to include building of Go-based projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,9 @@ None.
 
 ## Dependencies ##
 
-This Ansible role depends on
-[cisagov/ansible-role-backports](https://github.com/cisagov/ansible-role-backports),
-since on Debian Buster we need a newer version of the `golang` package
-in order to build Go-based projects.
+- [cisagov/ansible-role-backports](https://github.com/cisagov/ansible-role-backports):
+  On Debian Buster we need a newer version of the `golang` package in order to
+  build Go-based projects.
 
 ## Example Playbook ##
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ None.
 | archive_src | A URL or a file path on the remote host pointing to an archive (tar or zip) containing the tool.  If left undefined then no archive will be installed, but the install directory will still be created and language-specific tooling will still be installed. | n/a | No |
 | csharp | A Boolean indicating whether or not the tool is written in C#; if it is then we will install the mono C# toolchain. | `false` | No |
 | go | A Boolean indicating whether or not the tool is written in Go; if it is then we will install the Go development toolchain. | `false` | No |
+| go_build | A Boolean indicating whether or not the Go tool should be built; if so then we will run `go build` from the project's root directory. | `true` | No |
 | group | The group that will own the directory where this tool is installed. | `root` | No |
 | install_dir | The directory on the remote host where the tool should be installed. | n/a | Yes |
 | mode | The mode to assign the directory where this tool is installed. | `0775` | No |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ None.
 
 ## Dependencies ##
 
-None.
+This Ansible role depends on
+[cisagov/ansible-role-backports](https://github.com/cisagov/ansible-role-backports),
+since on Debian Buster we need a newer version of the `golang` package
+in order to build Go-based projects.
 
 ## Example Playbook ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,10 @@ csharp: no
 # toolchain required to compile Go code
 go: no
 
+# If yes then the Go project will be built via running go build from
+# the project's root directory
+go_build: yes
+
 # Group ownership for the install directory
 group: root
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,7 +31,10 @@ galaxy_info:
         # - bookworm
     - name: Ubuntu
       versions:
-        - bionic
+        # Bionic does not have a new enough version of the golang
+        # package to support building of Go tools via a simple go
+        # build, even in the backports repository.
+        # - bionic
         - focal
   role_name: assessment_tool
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -35,4 +35,6 @@ galaxy_info:
         - focal
   role_name: assessment_tool
 
-dependencies: []
+dependencies:
+  - src: https://github.com/cisagov/ansible-role-backports
+    name: backports

--- a/molecule/csharp/molecule.yml
+++ b/molecule/csharp/molecule.yml
@@ -22,8 +22,11 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: ubuntu18
-    image: ubuntu:bionic
+  # Bionic does not have a new enough version of the golang package to
+  # support building of Go tools via a simple go build, even in the
+  # backports repository.
+  # - name: ubuntu18
+  #   image: ubuntu:bionic
   - name: ubuntu20
     image: ubuntu:focal
 provisioner:

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -22,8 +22,11 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: ubuntu18
-    image: ubuntu:bionic
+  # Bionic does not have a new enough version of the golang package to
+  # support building of Go tools via a simple go build, even in the
+  # backports repository.
+  # - name: ubuntu18
+  #   image: ubuntu:bionic
   - name: ubuntu20
     image: ubuntu:focal
 provisioner:

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,6 @@
 ---
+- src: https://github.com/cisagov/ansible-role-backports
+  name: backports
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
 - src: https://github.com/cisagov/ansible-role-python

--- a/molecule/go/molecule.yml
+++ b/molecule/go/molecule.yml
@@ -22,8 +22,11 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: ubuntu18
-    image: ubuntu:bionic
+  # Bionic does not have a new enough version of the golang package to
+  # support building of Go tools via a simple go build, even in the
+  # backports repository.
+  # - name: ubuntu18
+  #   image: ubuntu:bionic
   - name: ubuntu20
     image: ubuntu:focal
 provisioner:

--- a/molecule/go/tests/test_go.py
+++ b/molecule/go/tests/test_go.py
@@ -2,6 +2,7 @@
 
 # Standard Python Libraries
 import os
+import stat
 
 # Third-Party Libraries
 import pytest
@@ -37,3 +38,17 @@ def test_directories(host, d):
 def test_packages(host, pkg):
     """Test that appropriate packages were installed."""
     assert host.package(pkg).is_installed
+
+
+@pytest.mark.parametrize(
+    "f",
+    [
+        "/tools/ScareCrow/ScareCrow",
+    ],
+)
+def test_build_products(host, f):
+    """Test that appropriate build products were created."""
+    ff = host.file(f)
+    assert ff.exists
+    assert ff.is_file
+    assert ff.mode & stat.S_IXUSR == stat.S_IXUSR

--- a/molecule/powershell/molecule.yml
+++ b/molecule/powershell/molecule.yml
@@ -22,8 +22,11 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: ubuntu18
-    image: ubuntu:bionic
+  # Bionic does not have a new enough version of the golang package to
+  # support building of Go tools via a simple go build, even in the
+  # backports repository.
+  # - name: ubuntu18
+  #   image: ubuntu:bionic
   - name: ubuntu20
     image: ubuntu:focal
 provisioner:

--- a/molecule/python/molecule.yml
+++ b/molecule/python/molecule.yml
@@ -22,8 +22,11 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: ubuntu18
-    image: ubuntu:bionic
+  # Bionic does not have a new enough version of the golang package to
+  # support building of Go tools via a simple go build, even in the
+  # backports repository.
+  # - name: ubuntu18
+  #   image: ubuntu:bionic
   - name: ubuntu20
     image: ubuntu:focal
 provisioner:

--- a/tasks/build_go_tool.yml
+++ b/tasks/build_go_tool.yml
@@ -1,0 +1,6 @@
+---
+- name: Build Go tool
+  ansible.builtin.command:
+    chdir: "{{ install_dir }}"
+    cmd: /usr/bin/go build
+    creates: "{{ install_dir | basename }}"

--- a/tasks/install_go.yml
+++ b/tasks/install_go.yml
@@ -1,19 +1,22 @@
 ---
-- name: Install Go toolchain and Git (Debian Buster and Ubuntu Bionic)
-  ansible.builtin.package:
-    name:
-      # Third-party Go packages are often installed via git
-      - git
-      - golang
-    default_release: "{{ ansible_distribution_release }}-backports"
-  when:
-    - (ansible_distribution == "Debian" and ansible_distribution_release == "buster") or (ansible_distribution == "Ubuntu" and ansible_distribution_release == "bionic")
+- name: Install Go toolchain
+  block:
+    - name: Install Go toolchain and Git (Debian Buster)
+      ansible.builtin.package:
+        name:
+          # Third-party Go packages are often installed via git
+          - git
+          - golang
+        default_release: "{{ ansible_distribution_release }}-backports"
+      when:
+        - ansible_distribution == "Debian"
+        - ansible_distribution_release == "buster"
 
-- name: Install Go toolchain and Git (not Debian Buster or Ubuntu Bionic)
-  ansible.builtin.package:
-    name:
-      # Third-party Go packages are often installed via git
-      - git
-      - golang
-  when:
-    - not ((ansible_distribution == "Debian" and ansible_distribution_release == "buster") or (ansible_distribution == "Ubuntu" and ansible_distribution_release == "bionic"))
+    - name: Install Go toolchain and Git (not Debian Buster)
+      ansible.builtin.package:
+        name:
+          # Third-party Go packages are often installed via git
+          - git
+          - golang
+      when:
+        - not (ansible_distribution == "Debian" and ansible_distribution_release == "buster")

--- a/tasks/install_go.yml
+++ b/tasks/install_go.yml
@@ -1,7 +1,19 @@
 ---
-- name: Install Go toolchain and Git
+- name: Install Go toolchain and Git (Debian Buster and Ubuntu Bionic)
   ansible.builtin.package:
     name:
       # Third-party Go packages are often installed via git
       - git
       - golang
+    default_release: "{{ ansible_distribution_release }}-backports"
+  when:
+    - (ansible_distribution == "Debian" and ansible_distribution_release == "buster") or (ansible_distribution == "Ubuntu" and ansible_distribution_release == "bionic")
+
+- name: Install Go toolchain and Git (not Debian Buster or Ubuntu Bionic)
+  ansible.builtin.package:
+    name:
+      # Third-party Go packages are often installed via git
+      - git
+      - golang
+  when:
+    - not ((ansible_distribution == "Debian" and ansible_distribution_release == "buster") or (ansible_distribution == "Ubuntu" and ansible_distribution_release == "bionic"))

--- a/tasks/install_tool.yml
+++ b/tasks/install_tool.yml
@@ -14,3 +14,9 @@
     group: "{{ group }}"
     remote_src: yes
     src: "{{ archive_src }}"
+  tags:
+    # The Ubuntu Focal version of the golang package is pretty old,
+    # and there is no newer version in backports.  When we build a
+    # project via go build, that version modifies or adds some files
+    # that cause this task to fail when idempotence runs.
+    - molecule-idempotence-notest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,12 @@
   when:
     - go
 
+- name: Build Go project if necessary
+  ansible.builtin.include_tasks: build_go_tool.yml
+  when:
+    - go
+    - go_build
+
 - name: Install mono if necessary
   ansible.builtin.include_tasks: install_mono.yml
   when:


### PR DESCRIPTION
## 🗣 Description ##

This pull request extends Go support to include building of Go-based assessment tools.

## 💭 Motivation and context ##

It is useful to pre-build Go-based assessment tools, since it saves some work on the part of the assessors.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
