### PR TITLE
Adjust dirsearch pip packages

### DIFF
--- a/molecule/python/tests/test_python.py
+++ b/molecule/python/tests/test_python.py
@@ -46,7 +46,7 @@ def test_packages(host, pkg):
         ("/tools/sshenum/.venv", ["paramiko"]),
         (
             "/tools/dirsearch/.venv",
-            ["certifi", "chardet", "urllib3", "cryptography", "PySocks"],
+            ["certifi", "urllib3", "cryptography", "cffi", "MarkupSafe"],
         ),
         ("/tools/mitm6/.venv", ["mitm6"]),
     ],


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes the list of `pip` packages checked for in the `molecule` tests to match what is actually installed via the project's `requirements.txt` file.

## 💭 Motivation and context ##

This Ansible role recently failed an APB build because the list of `pip` packages being installed did not match the list of `pip` packages being checked in the `molecule` tests.  The APB build failed because the `requirements.txt` file was recently changed.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests now pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.