### PR TITLE
Allow the user to specify extra arguments to pass to pip

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ None.
 | install_dir | The directory on the remote host where the tool should be installed. | n/a | Yes |
 | mode | The mode to assign the directory where this tool is installed. | `0775` | No |
 | owner | The user that will own the directory where this tool is installed. | `root` | No |
+| pip_extra_args | A extra arguments to give to pip when installing packages into the Python virtualenv. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 | pip_packages | A list of pip packages to install into the Python virtualenv. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 | pip_requirements_file | The path to a pip requirements file listing dependencies to install into the Python virtualenv. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 | powershell | A Boolean indicating whether or not the tool is written in PowerShell; if it is then we will install the powershell system package. | `false` | No |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ None.
 | install_dir | The directory on the remote host where the tool should be installed. | n/a | Yes |
 | mode | The mode to assign the directory where this tool is installed. | `0775` | No |
 | owner | The user that will own the directory where this tool is installed. | `root` | No |
-| pip_extra_args | A extra arguments to give to pip when installing packages into the Python virtualenv. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
+| pip_extra_args | Extra arguments to give to pip when installing packages into the Python virtualenv. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 | pip_packages | A list of pip packages to install into the Python virtualenv. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 | pip_requirements_file | The path to a pip requirements file listing dependencies to install into the Python virtualenv. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 | powershell | A Boolean indicating whether or not the tool is written in PowerShell; if it is then we will install the powershell system package. | `false` | No |

--- a/tasks/create_python_venv.yml
+++ b/tasks/create_python_venv.yml
@@ -8,6 +8,7 @@
 - name: Create the virtualenv
   ansible.builtin.pip:
     chdir: "{{ install_dir }}"
+    extra_args: "{{ pip_extra_args | default(omit) }}"
     name: "{{ pip_packages | default(omit) }}"
     requirements: "{{ pip_requirements_file | default(omit) }}"
     virtualenv: "{{ virtualenv_dir | default((install_dir, '.venv') | path_join) }}"


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the ability for the user to specify extra arguments to pass to `pip` when installing packages into the Python virtual environment.

## 💭 Motivation and context ##

This change is required to satisfy JIRA ticket [CAL-17017](https://jira.ceil.cyber.dhs.gov/projects/CAL/queues/custom/9/CAL-17017).  One of the tools that was requested has a faulty `setup.py` file that causes the package to fully function only when installed via `pip install -editable .`; a simple `pip install .` does not suffice.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.