### PR TITLE
Use the latest PowerShell release

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,3 @@
 ---
 # The name of the package to install for PowerShell
-powershell_package_name: https://github.com/PowerShell/PowerShell/releases/download/v7.2.1/powershell_7.2.1-1.deb_amd64.deb
+powershell_package_name: https://github.com/PowerShell/PowerShell/releases/download/v7.2.6/powershell_7.2.6-1.deb_amd64.deb


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Ansible role to use the latest [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell) release.

## 💭 Motivation and context ##

In addition to being the latest and greatest, the latest PowerShell release fixes a bug where PowerShell could not be installed on Debian 12.  This bug was due to the fact that older versions of PowerShell required an older version of the `libssl` package that Debian 12 does not provide. 

This bug has been causing APB builds to fail ([1](https://github.com/cisagov/ansible-role-assessment-tool/actions/runs/3045807313), [2](https://github.com/cisagov/ansible-role-assessment-tool/actions/runs/3000482150), [3](https://github.com/cisagov/ansible-role-assessment-tool/actions/runs/2956120418)), so it needs to be fixed.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.