### PR TITLE
Prefer long command line options for clarity

### DIFF
--- a/molecule/csharp/tests/test_csharp.py
+++ b/molecule/csharp/tests/test_csharp.py
@@ -24,7 +24,7 @@ def test_directories(host, d):
     assert directory.exists
     assert directory.is_directory
     # Make sure that the directory is not empty
-    assert host.run_expect([0], f'[ -n "$(ls -A {d})" ]')
+    assert host.run_expect([0], f'[ -n "$(ls --almost-all {d})" ]')
 
 
 @pytest.mark.parametrize(

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -25,4 +25,4 @@ def test_directories(host, d):
     assert directory.exists
     assert directory.is_directory
     # Make sure that the directory is not empty
-    assert host.run_expect([0], f'[ -n "$(ls -A {d})" ]')
+    assert host.run_expect([0], f'[ -n "$(ls --almost-all {d})" ]')

--- a/molecule/go/tests/test_go.py
+++ b/molecule/go/tests/test_go.py
@@ -25,7 +25,7 @@ def test_directories(host, d):
     assert directory.exists
     assert directory.is_directory
     # Make sure that the directory is not empty
-    assert host.run_expect([0], f'[ -n "$(ls -A {d})" ]')
+    assert host.run_expect([0], f'[ -n "$(ls --almost-all {d})" ]')
 
 
 @pytest.mark.parametrize(

--- a/molecule/powershell/tests/test_powershell.py
+++ b/molecule/powershell/tests/test_powershell.py
@@ -24,7 +24,7 @@ def test_directories(host, d):
     assert directory.exists
     assert directory.is_directory
     # Make sure that the directory is not empty
-    assert host.run_expect([0], f'[ -n "$(ls -A {d})" ]')
+    assert host.run_expect([0], f'[ -n "$(ls --almost-all {d})" ]')
 
 
 @pytest.mark.parametrize(

--- a/molecule/python/tests/test_python.py
+++ b/molecule/python/tests/test_python.py
@@ -26,7 +26,7 @@ def test_directories(host, d):
     assert directory.exists
     assert directory.is_directory
     # Make sure that the directory is not empty
-    assert host.run_expect([0], f'[ -n "$(ls -A {d})" ]')
+    assert host.run_expect([0], f'[ -n "$(ls --almost-all {d})" ]')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies a test to prefer a long command line option.

## 💭 Motivation and context ##

We prefer long command line options as their function is usually more obvious and thus we avoid having to read a `man` page to understand what they are doing.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.