### PR TITLE
Add a blurb about using include_role and/or import_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ link](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.h
 and [this
 link](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-private-role-vars).
 
+As an alternative, you might also consider using the
+[`ansible.builtin.include_role`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_role_module.html)
+and/or
+[`ansible.builtin.import_role`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/import_role_module.html)
+Ansible modules instead of including roles via the `roles:` section of
+the playbook.  Including Ansible roles using these modules does not
+result in their variables being added to the play variables and
+therefore avoids this issue altogether.
+
 ## Requirements ##
 
 None.


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a blurb to the `README.md` file about making use of the `ansible.builtin.include_role` and/or `ansible.builtin.import_role` modules instead of including Ansible roles via the `roles:` section of the Ansible playbook.

## 💭 Motivation and context ##

Including Ansible roles in this way avoids the need to make use of the `private_role_vars` configuration setting.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updatedto reflect the changes in this PR.
- [x] All new and existing tests pass.