### PR TITLE
Pin impacket when installing HarmJ0y/ImpDump

### DIFF
--- a/molecule/python2/converge.yml
+++ b/molecule/python2/converge.yml
@@ -25,7 +25,9 @@
         assessment_tool_archive_src: https://github.com/HarmJ0y/ImpDump/tarball/master
         assessment_tool_install_dir: /tools/ImpDump
         assessment_tool_pip_packages:
-          - impacket
+          # impacket>=0.11.0 has a dependency that only supports
+          # Python 3.
+          - impacket<0.11.0
           - pycrypto
         assessment_tool_python2: true
         assessment_tool_python_install_development_dependencies: true


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes the installation of [HarmJ0y/ImpDump](https://github.com/HarmJ0y/ImpDump), which is currently broken.

## 💭 Motivation and context ##

[HarmJ0y/ImpDump](https://github.com/HarmJ0y/ImpDump) is a Python 2 tool with a dependency on the [`impacket`](https://pypi.org/project/impacket/) Python package.  The latest release of [`impacket`](https://pypi.org/project/impacket/) has a dependency that only supports Python 3, so we need to pin [`impacket`](https://pypi.org/project/impacket/) when installing [HarmJ0y/ImpDump](https://github.com/HarmJ0y/ImpDump).

See also cisagov/kali-packer#152.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.