### PR TITLE
Uninstall `virtualenv` system package before installing it via `pip`

### DIFF
--- a/molecule/python2/tests/test_python2.py
+++ b/molecule/python2/tests/test_python2.py
@@ -30,17 +30,6 @@ def test_directories(host, d):
 
 
 @pytest.mark.parametrize(
-    "pkg",
-    [
-        "virtualenv",
-    ],
-)
-def test_pip_packages(host, pkg):
-    """Test that appropriate pip packages were installed."""
-    assert pkg in host.pip.get_packages(pip_path="pip3")
-
-
-@pytest.mark.parametrize(
     "d,pkgs",
     [
         # No pip packages installed

--- a/tasks/create_python_venv.yml
+++ b/tasks/create_python_venv.yml
@@ -8,14 +8,36 @@
           - virtualenv
       when: not assessment_tool_python2
 
-    - name: Install virtualenv via pip
-      ansible.builtin.pip:
-        name:
-          # virtualenv 20.22.0 removed support for creating Python 2
-          # venvs:
-          # https://virtualenv.pypa.io/en/latest/changelog.html#v20-22-0-2023-04-19
-          - virtualenv<20.22.0
+    # The shadiness is necessary because, on modern distributions, pip
+    # (correctly) refuses to uninstall Python packages installed via
+    # system packages.
+    - name: Shadily install virtualenv for Python 2 via pip
       when: assessment_tool_python2
+      tags:
+        # This kind of chicanery can never pass idempotence.
+        - molecule-idempotence-notest
+      block:
+        # We can revert to the system packages that provide virtualenv
+        # and platformdirs once the Python 2 virtual environment is
+        # created.
+        - name: >-
+            Shadily uninstall some Python 3 packages via the package
+            manager
+          ansible.builtin.package:
+            name:
+              - python3-platformdirs
+              - virtualenv
+            state: absent
+          register: shady_uninstall
+        - name: Shadily install necessary packages for Python 2 via pip
+          ansible.builtin.pip:
+            name:
+              - platformdirs
+              # virtualenv 20.22.0 removed support for creating Python 2
+              # venvs:
+              # https://virtualenv.pypa.io/en/latest/changelog.html#v20-22-0-2023-04-19
+              - virtualenv<20.22.0
+          register: shady_install
 
 - name: Create the virtualenv
   ansible.builtin.pip:
@@ -25,3 +47,34 @@
     requirements: "{{ assessment_tool_pip_requirements_file | default(omit) }}"
     virtualenv: "{{ assessment_tool_virtualenv_dir | default((assessment_tool_install_dir, '.venv') | path_join) }}"
     virtualenv_python: "{{ (assessment_tool_python2) | ternary('/usr/bin/python2', omit) }}"
+
+# Undo the shadiness that was done in order to create a Python 2
+# virtual environment.
+- name: Cleanup Python 2 chicanery
+  tags:
+    # This kind of chicanery can never pass idempotence.
+    - molecule-idempotence-notest
+  block:
+    - name: Uninstall shadily-installed virtualenv for Python 2 via pip
+      # The following line triggers an error from ansible-lint that
+      # "Tasks that run when changed should likely be handlers" but we
+      # need to undo this chicanery _now_ and not wait until handlers
+      # run.
+      when: shady_install.changed  # noqa: no-handler
+      ansible.builtin.pip:
+        name:
+          - platformdirs
+          - virtualenv
+        state: absent
+    - name: >-
+        Install shadily-uninstalled virtualenv for Python 3 via the
+        package manager
+      # The following line triggers an error from ansible-lint that
+      # "Tasks that run when changed should likely be handlers" but we
+      # need to undo this chicanery _now_ and not wait until handlers
+      # run.
+      when: shady_uninstall.changed  # noqa: no-handler
+      ansible.builtin.package:
+        name:
+          # This will pull in python3-platformdirs if necessary.
+          - virtualenv

--- a/tasks/create_python_venv.yml
+++ b/tasks/create_python_venv.yml
@@ -11,6 +11,8 @@
     # The shadiness is necessary because, on modern distributions, pip
     # (correctly) refuses to uninstall Python packages installed via
     # system packages.
+    #
+    # TODO: This nonsense will not work forever.  See #56 for details.
     - name: Shadily install virtualenv for Python 2 via pip
       when: assessment_tool_python2
       tags:
@@ -50,6 +52,8 @@
 
 # Undo the shadiness that was done in order to create a Python 2
 # virtual environment.
+#
+# TODO: This nonsense will not work forever.  See #56 for details.
 - name: Cleanup Python 2 chicanery
   tags:
     # This kind of chicanery can never pass idempotence.


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to uninstall the `virtualenv` system package for Python 3 before installing `virtualenv` for Python 2 via `pip`.

## 💭 Motivation and context ##

On modern distributions, `pip` (correctly) refuses to uninstall Python packages installed via system packages.  This was found to cause [build errors](https://github.com/cisagov/kali-packer/actions/runs/8266179719/job/22613823230) in the testing that was done as part of cisagov/kali-packer#165.

## 🧪 Testing ##

All automated tests pass.  In the testing that was done as part of cisagov/kali-packer#165, I verified that these changes fix the build errors mentioned above.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.