### PR TITLE
Add `--break-system-packages` to shady `pip` commands if supported

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,10 @@ jobs:
             scenario: python2
           - platform: debian13-systemd
             scenario: python2
+          # Kali cannot build the wheels for HarmJ0y/ImpDump on ARM64.
+          - architecture: arm64
+            platform: kali-systemd
+            scenario: python2
           # Ubuntu Noble does not offer Python 2.
           - platform: ubuntu-24-systemd
             scenario: python2

--- a/molecule/python2/molecule.yml
+++ b/molecule/python2/molecule.yml
@@ -105,15 +105,16 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/cisagov/docker-kali-ansible:latest
-    name: kali-systemd-arm64
-    platform: arm64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # Kali cannot build the wheels for HarmJ0y/ImpDump on ARM64.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/cisagov/docker-kali-ansible:latest
+  #   name: kali-systemd-arm64
+  #   platform: arm64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   # This Ansible role only supports Debian-based platforms for now.
   # - cgroupns_mode: host
   #   command: /lib/systemd/systemd

--- a/tasks/create_python_venv.yml
+++ b/tasks/create_python_venv.yml
@@ -8,6 +8,13 @@
           - virtualenv
       when: not assessment_tool_python2
 
+    - name: Set pip_break_system_packages if necessary
+      ansible.builtin.set_fact:
+        pip_break_system_packages: --break-system-packages
+      when:
+        - ansible_distribution in ["Debian", "Kali", "Ubuntu"]
+        - ansible_distribution_release not in ["bullseye", "buster", "focal", "jammy"]
+
     # The shadiness is necessary because, on modern distributions, pip
     # (correctly) refuses to uninstall Python packages installed via
     # system packages.
@@ -33,6 +40,7 @@
           register: shady_uninstall
         - name: Shadily install necessary packages for Python 2 via pip
           ansible.builtin.pip:
+            extra_args: "{{ pip_break_system_packages | default(omit) }}"
             name:
               - platformdirs
               # virtualenv 20.22.0 removed support for creating Python 2
@@ -66,6 +74,7 @@
       # run.
       when: shady_install.changed  # noqa: no-handler
       ansible.builtin.pip:
+        extra_args: "{{ pip_break_system_packages | default(omit) }}"
         name:
           - platformdirs
           - virtualenv


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Ansible code to use the `--break-system-packages` command when running the "shady" `pip` commands necessary to support Python 2.

## 💭 Motivation and context ##

Kali Linux refuses to perform these `pip` commands without `--break-system-packages`, [as can be seen in this failing APB build](https://github.com/cisagov/ansible-role-assessment-tool/actions/runs/10916548463/job/30331415526), but not all the platforms we support actually have a new enough version of `pip` to accept this CLI flag.

These shady `pip` commands are OK to perform since afterwards we are putting everything back the way we found it.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.