### PR TITLE
Remove support for Debian Buster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,10 +181,6 @@ jobs:
           - amd64
           - arm64
         exclude:
-          # Buster does not have a new enough version of the golang
-          # package to build any go projects of recent vintage.
-          - platform: debian10-systemd
-            scenario: go
           # Focal does not have a new enough version of the golang
           # package to build any go projects of recent vintage.
           - platform: ubuntu-20-systemd
@@ -198,10 +194,6 @@ jobs:
           # https://packages.ubuntu.com/search?keywords=libicu&searchon=names&suite=noble&section=all
           - platform: ubuntu-24-systemd
             scenario: powershell
-          # Buster does not offer a new enough version of Python 3 to
-          # support some of the tools that are installed.
-          - platform: debian10-systemd
-            scenario: python
           # Debian Bookworm and Trixie do not offer Python 2.
           - platform: debian12-systemd
             scenario: python2
@@ -214,11 +206,6 @@ jobs:
           # Ubuntu Noble does not offer Python 2.
           - platform: ubuntu-24-systemd
             scenario: python2
-          # Debian Buster does not have a new enough version of cargo
-          # to parse the cargo.toml file for RustScan.  The
-          # buster-backports package repository no longer exists.
-          - platform: debian10-systemd
-            scenario: rust
           # Debian Bullseye has an older version of cargo, which gives
           # a "feature `resolver` is required" error when installing
           # RustScan.  There is no newer version in backports.
@@ -235,7 +222,6 @@ jobs:
           # This Ansible role only supports Debian-based platforms for
           # now.
           # - amazonlinux2023-systemd
-          - debian10-systemd
           - debian11-systemd
           - debian12-systemd
           - debian13-systemd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,10 @@ jobs:
           # https://packages.ubuntu.com/search?keywords=libicu&searchon=names&suite=noble&section=all
           - platform: ubuntu-24-systemd
             scenario: powershell
+          # Buster does not offer a new enough version of Python 3 to
+          # support some of the tools that are installed.
+          - platform: debian10-systemd
+            scenario: python
           # Debian Bookworm and Trixie do not offer Python 2.
           - platform: debian12-systemd
             scenario: python2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,7 +32,9 @@ galaxy_info:
     #     - "2023"
     - name: Debian
       versions:
-        - buster
+        # Buster's version of Python is too old to support some of the
+        # tools that are installed.
+        # - buster
         - bullseye
         - bookworm
         - trixie

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -33,7 +33,10 @@ galaxy_info:
     - name: Debian
       versions:
         # Buster's version of Python is too old to support some of the
-        # tools that are installed.
+        # tools that are installed.  Its versions of the Rust and Go
+        # toolchains are also too old to build projects of recent
+        # vintage.  So we're dropping support for this antiquated
+        # platform.
         # - buster
         - bullseye
         - bookworm

--- a/molecule/csharp/molecule.yml
+++ b/molecule/csharp/molecule.yml
@@ -25,24 +25,6 @@ platforms:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-amd64
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-arm64
-    platform: arm64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian11-ansible:latest
     name: debian11-systemd-amd64
     platform: amd64

--- a/molecule/go/molecule.yml
+++ b/molecule/go/molecule.yml
@@ -23,26 +23,6 @@ platforms:
   #   privileged: true
   #   volumes:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # Buster does not have a new enough version of the golang package to
-  # build any go projects of recent vintage.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
-  #   name: debian10-systemd-amd64
-  #   platform: amd64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
-  #   name: debian10-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian11-ansible:latest

--- a/molecule/powershell/molecule.yml
+++ b/molecule/powershell/molecule.yml
@@ -25,25 +25,6 @@ platforms:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-amd64
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # PowerShell does not support ARM64 on Debian.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
-  #   name: debian10-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian11-ansible:latest
     name: debian11-systemd-amd64
     platform: amd64

--- a/molecule/python/molecule.yml
+++ b/molecule/python/molecule.yml
@@ -23,26 +23,6 @@ platforms:
   #   privileged: true
   #   volumes:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # Buster's version of Python 3 is too old to support some of the
-  # tools that are installed.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
-  #   name: debian10-systemd-amd64
-  #   platform: amd64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
-  #   name: debian10-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian11-ansible:latest

--- a/molecule/python/molecule.yml
+++ b/molecule/python/molecule.yml
@@ -23,24 +23,26 @@ platforms:
   #   privileged: true
   #   volumes:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-amd64
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-arm64
-    platform: arm64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # Buster's version of Python 3 is too old to support some of the
+  # tools that are installed.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
+  #   name: debian10-systemd-amd64
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
+  #   name: debian10-systemd-arm64
+  #   platform: arm64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian11-ansible:latest

--- a/molecule/python2/molecule.yml
+++ b/molecule/python2/molecule.yml
@@ -25,24 +25,6 @@ platforms:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-amd64
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-arm64
-    platform: arm64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian11-ansible:latest
     name: debian11-systemd-amd64
     platform: amd64

--- a/molecule/rust/molecule.yml
+++ b/molecule/rust/molecule.yml
@@ -23,27 +23,6 @@ platforms:
   #   privileged: true
   #   volumes:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # Debian Buster does not have a new enough version of cargo to parse
-  # the cargo.toml file for RustScan.  The buster-backports package
-  # repository no longer exists.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
-  #   name: debian10-systemd-amd64
-  #   platform: amd64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
-  #   name: debian10-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   # Debian Bullseye has an older version of cargo, which gives a
   # "feature `resolver` is required" error when installing RustScan.
   # There is no newer version in backports.

--- a/tasks/create_python_venv.yml
+++ b/tasks/create_python_venv.yml
@@ -13,7 +13,7 @@
         pip_break_system_packages: --break-system-packages
       when:
         - ansible_distribution in ["Debian", "Kali", "Ubuntu"]
-        - ansible_distribution_release not in ["bullseye", "buster", "focal", "jammy"]
+        - ansible_distribution_release not in ["bullseye", "focal", "jammy"]
 
     # The shadiness is necessary because, on modern distributions, pip
     # (correctly) refuses to uninstall Python packages installed via

--- a/tasks/install_go.yml
+++ b/tasks/install_go.yml
@@ -1,15 +1,15 @@
 ---
 - name: Install Go toolchain
   block:
-    - name: Install Go toolchain (Debian Buster or Bullseye)
+    - name: Install Go toolchain (Debian Bullseye)
       when:
         - ansible_distribution == "Debian"
-        - ansible_distribution_release in ["buster", "bullseye"]
+        - ansible_distribution_release in ["bullseye"]
       block:
-        - name: Setup backports (Debian Buster or Bullseye)
+        - name: Setup backports (Debian Bullseye)
           ansible.builtin.include_role:
             name: backports
-        - name: Install Go toolchain and Git (Debian Buster or Bullseye)
+        - name: Install Go toolchain and Git (Debian Bullseye)
           ansible.builtin.package:
             default_release: "{{ ansible_distribution_release }}-backports"
             name:
@@ -17,11 +17,11 @@
               - git
               - golang
 
-    - name: Install Go toolchain and Git (not Debian Buster or Bullseye)
+    - name: Install Go toolchain and Git (not Debian Bullseye)
       ansible.builtin.package:
         name:
           # Third-party Go packages are often installed via git
           - git
           - golang
       when:
-        - not (ansible_distribution == "Debian" and ansible_distribution_release in ["buster", "bullseye"])
+        - not (ansible_distribution == "Debian" and ansible_distribution_release in ["bullseye"])


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes support for Debian Buster in all scenarios.

## 💭 Motivation and context ##

Buster's version of Python 3 is too old to support some of the tools that are installed, e.g., [maurosoria/dirsearch](https://github.com/maurosoria/dirsearch) which requires Python 3.8 or later.

Buster's Go and Rust support is also lacking, so it makes sense to just drop this antiquated platform.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Remove Debian Buster GH Actions checks as required.