### PR TITLE
Reinstate `tarrell13/Auto-Egress-Assess` testing in `python` scenario

### DIFF
--- a/molecule/python/converge.yml
+++ b/molecule/python/converge.yml
@@ -2,6 +2,18 @@
 - name: Converge
   hosts: all
   tasks:
+    - name: Install Auto-Egress-Assess in a venv via pipenv
+      # We do prepend the name of the role to the role variables, but
+      # Molecule does its own role discovery with inconsistent naming.
+      # This is the reason for the noqa below.
+      ansible.builtin.include_role: # noqa var-naming[no-role-prefix]
+        name: ansible-role-assessment-tool
+      vars:
+        assessment_tool_archive_src: https://github.com/tarrell13/Auto-Egress-Assess/tarball/main
+        assessment_tool_install_dir: /tools/Auto-Egress-Assess
+        assessment_tool_pipenv: true
+        assessment_tool_unarchive_extra_opts:
+          - --strip-components=1
     - name: Install sshenum and a pip package in a venv
       # We do prepend the name of the role to the role variables, but
       # Molecule does its own role discovery with inconsistent naming.

--- a/molecule/python/converge.yml
+++ b/molecule/python/converge.yml
@@ -9,11 +9,14 @@
       ansible.builtin.include_role: # noqa var-naming[no-role-prefix]
         name: ansible-role-assessment-tool
       vars:
-        assessment_tool_archive_src: https://github.com/tarrell13/Auto-Egress-Assess/tarball/main
+        # Version 2.0.0 and later require Python 3.13 or newer,
+        # whereas version 1.0.0 works with any version of Python 3.
+        assessment_tool_archive_src: https://github.com/tarrell13/Auto-Egress-Assess/tarball/v1.0.0
         assessment_tool_install_dir: /tools/Auto-Egress-Assess
         assessment_tool_pipenv: true
         assessment_tool_unarchive_extra_opts:
           - --strip-components=1
+
     - name: Install sshenum and a pip package in a venv
       # We do prepend the name of the role to the role variables, but
       # Molecule does its own role discovery with inconsistent naming.

--- a/molecule/python/converge.yml
+++ b/molecule/python/converge.yml
@@ -30,6 +30,7 @@
           - paramiko
         assessment_tool_unarchive_extra_opts:
           - --strip-components=1
+
     # yamllint/ansible-lint complain about a long line in this
     # comment, but there is nothing I can do to shorten it.
     #
@@ -48,6 +49,7 @@
     #     assessment_tool_pip_packages:
     #       - '.'
     # yamllint enable rule:line-length
+
     - name: Install dirsearch and a requirements file in a venv
       # We do prepend the name of the role to the role variables, but
       # Molecule does its own role discovery with inconsistent naming.
@@ -60,6 +62,7 @@
         assessment_tool_pip_requirements_file: requirements.txt
         assessment_tool_unarchive_extra_opts:
           - --strip-components=1
+
     - name: Install the mitm6 package in a venv
       # We do prepend the name of the role to the role variables, but
       # Molecule does its own role discovery with inconsistent naming.
@@ -79,6 +82,7 @@
         # Ubuntu 20:
         # https://packages.ubuntu.com/search?suite=focal&searchon=names&keywords=python3
         - molecule-idempotence-notest
+
     - name: Install the sqlmap tool
       # We do prepend the name of the role to the role variables, but
       # Molecule does its own role discovery with inconsistent naming.

--- a/molecule/python/converge.yml
+++ b/molecule/python/converge.yml
@@ -3,19 +3,38 @@
   hosts: all
   tasks:
     - name: Install Auto-Egress-Assess in a venv via pipenv
-      # We do prepend the name of the role to the role variables, but
-      # Molecule does its own role discovery with inconsistent naming.
-      # This is the reason for the noqa below.
-      ansible.builtin.include_role: # noqa var-naming[no-role-prefix]
-        name: ansible-role-assessment-tool
-      vars:
-        # Version 2.0.0 and later require Python 3.13 or newer,
-        # whereas version 1.0.0 works with any version of Python 3.
-        assessment_tool_archive_src: https://github.com/tarrell13/Auto-Egress-Assess/tarball/v1.0.0
-        assessment_tool_install_dir: /tools/Auto-Egress-Assess
-        assessment_tool_pipenv: true
-        assessment_tool_unarchive_extra_opts:
-          - --strip-components=1
+      block:
+        # After version 1.0.0 this tool requires Python 3.13 or newer
+        - name: >-
+            Determine the version of Auto-Egress-Assess that should be
+            installed
+          block:
+            - name: Set the version for Python<3.13
+              ansible.builtin.set_fact:
+                aea_version: v1.0.0
+              when:
+                - ansible_python_version is ansible.builtin.version("3.13", "<")
+
+            - name: Set the version for Python>=3.13
+              ansible.builtin.set_fact:
+                aea_version: main
+              when:
+                - ansible_python_version is ansible.builtin.version("3.13", ">=")
+
+        - name: Install Auto-Egress-Assess in a venv via pipenv
+          # We do prepend the name of the role to the role variables,
+          # but Molecule does its own role discovery with inconsistent
+          # naming.  This is the reason for the noqa below.
+          ansible.builtin.include_role: # noqa var-naming[no-role-prefix]
+            name: ansible-role-assessment-tool
+          vars:
+            assessment_tool_archive_src: >-
+              https://github.com/tarrell13/Auto-Egress-Assess/tarball/{{
+              aea_version }}
+            assessment_tool_install_dir: /tools/Auto-Egress-Assess
+            assessment_tool_pipenv: true
+            assessment_tool_unarchive_extra_opts:
+              - --strip-components=1
 
     - name: Install sshenum and a pip package in a venv
       # We do prepend the name of the role to the role variables, but

--- a/molecule/python/tests/test_python.py
+++ b/molecule/python/tests/test_python.py
@@ -15,6 +15,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 @pytest.mark.parametrize(
     "d",
     [
+        "/tools/Auto-Egress-Assess",
         "/tools/dirsearch",
         "/tools/mitm6",
         "/tools/sqlmap",
@@ -33,6 +34,7 @@ def test_directories(host, d):
 @pytest.mark.parametrize(
     "pkg",
     [
+        "pipenv",
         "virtualenv",
     ],
 )
@@ -44,6 +46,32 @@ def test_packages(host, pkg):
 @pytest.mark.parametrize(
     "d,pkgs",
     [
+        (
+            "/tools/Auto-Egress-Assess/.venv",
+            [
+                # This package shows up with a different name in pip list
+                # (bdist_mpkg versus bdist-mpkg) depending on the platform on
+                # which it is installed, so we will skip testing for it.
+                # "bdist_mpkg",
+                "chardet",
+                "dnslib",
+                "impacket",
+                # This package shows up with a different name in pip list
+                # (importlib_metadata versus importlib-metadata) depending on
+                # the platform on which it is installed, so we will skip
+                # testing for it.
+                # "importlib_metadata",
+                "paramiko",
+                "progress",
+                "py2app",
+                "pyftpdlib",
+                "pyparsing",
+                "python-dateutil",
+                "pytz",
+                "requests",
+                "scapy",
+            ],
+        ),
         (
             "/tools/dirsearch/.venv",
             [


### PR DESCRIPTION
## 🗣 Description ##

This pull request reinstates testing of [tarrell13/Auto-Egress-Assess](https://github.com/tarrell13/Auto-Egress-Assess) in the `python` scenario.  This testing was previously removed in #69.

## 💭 Motivation and context ##

Since #69 was merged we learned that the `v1.0.0` tag of [tarrell13/Auto-Egress-Assess](https://github.com/tarrell13/Auto-Egress-Assess) should be used for pre-3.13 versions of Python.  It is good to test the installation of [tarrell13/Auto-Egress-Assess](https://github.com/tarrell13/Auto-Egress-Assess) since that may catch some errors before they surface in [cisagov/egress-assess-packer](https://github.com/cisagov/egress-assess-packer), so it makes sense to add it back in now that we know how.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
