### PR TITLE
Remove dirsearch from Molecule testing

### DIFF
--- a/molecule/python/converge.yml
+++ b/molecule/python/converge.yml
@@ -72,6 +72,8 @@
     # This tool can no longer be installed on Bullseye because it pins
     # mysql-connector-python to version 9.5.0, which requires Python
     # 3.10 or later.  Bullseye only provides Python 3.9.
+    #
+    # TODO - Revert this change.  See #78 for more details.
     # - name: Install dirsearch and a requirements file in a venv
     #   # We do prepend the name of the role to the role variables, but
     #   # Molecule does its own role discovery with inconsistent naming.

--- a/molecule/python/converge.yml
+++ b/molecule/python/converge.yml
@@ -69,18 +69,22 @@
     #       - '.'
     # yamllint enable rule:line-length
 
-    - name: Install dirsearch and a requirements file in a venv
-      # We do prepend the name of the role to the role variables, but
-      # Molecule does its own role discovery with inconsistent naming.
-      # This is the reason for the noqa below.
-      ansible.builtin.include_role: # noqa var-naming[no-role-prefix]
-        name: ansible-role-assessment-tool
-      vars:
-        assessment_tool_archive_src: https://github.com/maurosoria/dirsearch/tarball/master
-        assessment_tool_install_dir: /tools/dirsearch
-        assessment_tool_pip_requirements_file: requirements.txt
-        assessment_tool_unarchive_extra_opts:
-          - --strip-components=1
+    # This tool can no longer be installed on Bullseye because it pins
+    # mysql-connector-python to version 9.5.0, which requires Python
+    # 3.10 or later.  Bullseye only provides Python 3.9.
+    # - name: Install dirsearch and a requirements file in a venv
+    #   # We do prepend the name of the role to the role variables, but
+    #   # Molecule does its own role discovery with inconsistent naming.
+    #   # This is the reason for the noqa below.
+    #   ansible.builtin.include_role: # noqa var-naming[no-role-prefix]
+    #     name: ansible-role-assessment-tool
+    #   vars:
+    #     assessment_tool_archive_src: >-
+    #       https://github.com/maurosoria/dirsearch/tarball/master
+    #     assessment_tool_install_dir: /tools/dirsearch
+    #     assessment_tool_pip_requirements_file: requirements.txt
+    #     assessment_tool_unarchive_extra_opts:
+    #       - --strip-components=1
 
     - name: Install the mitm6 package in a venv
       # We do prepend the name of the role to the role variables, but

--- a/molecule/python/tests/test_python.py
+++ b/molecule/python/tests/test_python.py
@@ -16,7 +16,10 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     "d",
     [
         "/tools/Auto-Egress-Assess",
-        "/tools/dirsearch",
+        # This tool can no longer be installed on Bullseye because it
+        # pins mysql-connector-python to version 9.5.0, which requires
+        # Python 3.10 or later.  Bullseye only provides Python 3.9.
+        # "/tools/dirsearch",
         "/tools/mitm6",
         "/tools/sqlmap",
         "/tools/sshenum",
@@ -72,15 +75,18 @@ def test_packages(host, pkg):
                 "scapy",
             ],
         ),
-        (
-            "/tools/dirsearch/.venv",
-            [
-                "certifi",
-                "cffi",
-                "cryptography",
-                "urllib3",
-            ],
-        ),
+        # This tool can no longer be installed on Bullseye because it
+        # pins mysql-connector-python to version 9.5.0, which requires
+        # Python 3.10 or later.  Bullseye only provides Python 3.9.
+        # (
+        #     "/tools/dirsearch/.venv",
+        #     [
+        #         "certifi",
+        #         "cffi",
+        #         "cryptography",
+        #         "urllib3",
+        #     ],
+        # ),
         ("/tools/mitm6/.venv", ["mitm6"]),
         # There is no venv for sqlmap since it has no dependencies.
         # ("/tools/sqlmap/.venv", []),

--- a/molecule/python/tests/test_python.py
+++ b/molecule/python/tests/test_python.py
@@ -19,6 +19,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
         # This tool can no longer be installed on Bullseye because it
         # pins mysql-connector-python to version 9.5.0, which requires
         # Python 3.10 or later.  Bullseye only provides Python 3.9.
+        #
+        # TODO - Revert this change.  See #78 for more details.
         # "/tools/dirsearch",
         "/tools/mitm6",
         "/tools/sqlmap",
@@ -78,6 +80,8 @@ def test_packages(host, pkg):
         # This tool can no longer be installed on Bullseye because it
         # pins mysql-connector-python to version 9.5.0, which requires
         # Python 3.10 or later.  Bullseye only provides Python 3.9.
+        #
+        # TODO - Revert this change.  See #78 for more details.
         # (
         #     "/tools/dirsearch/.venv",
         #     [


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes `dirsearch` from the list of tools installed in the `python` Molecule scenario.

## 💭 Motivation and context ##

This tool can no longer be installed on Bullseye because it pins `mysql-connector-python` to version 9.5.0, which requires Python 3.10 or later.  Bullseye only provides Python 3.9.

Without this change [APB testing fails](https://github.com/cisagov/ansible-role-assessment-tool/actions/runs/22168810878).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.